### PR TITLE
Give the middleware function a name

### DIFF
--- a/lib/staticTransform.js
+++ b/lib/staticTransform.js
@@ -5,7 +5,7 @@ var parse = require('connect/lib/utils').parseUrl,
     nPath = require('path');
 
 // Export middleware factory
-module.exports = createMiddleware;;
+module.exports = createMiddleware;
 
 // Generate CSS Regex
 var cssRegex = function (path) {
@@ -49,7 +49,7 @@ function createMiddleware(options) {
   var cache = {};
 
   // Return middleware function
-  return function (req, res, next) {
+  return function staticTransform(req, res, next) {
     // Check request method
     if (req.method !== 'GET' && req.method !== 'HEAD') {
       return next();


### PR DESCRIPTION
While using connect with the `DEBUG` variable set to true, this library logs:

```
connect:dispatcher use / anonymous
```

With this fix, it instead logs:

```
connect:dispatcher use / staticTransform
```