### PR TITLE
Option to pass "Expires" header as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ If set to `true` or an otherwise truthy value, the transformed data for each pat
 
 Used in conjunction with `cache`, this indicates the maximum age in seconds a client should keep the file cached for. This will not expire the local in-memory cache.
 
+`expires`
+
+Optionally you can set the `Expires` response header. Defaults to 1 year.
+
 `encoding`
 
 The encoding of the files which are opened for transformation. Defaults to `'utf-8'`. If set to `'buffer'` then the transformation function will receive a raw data buffer (see [`fs.readFile(...)`](http://nodejs.org/api/fs.html#fs_fs_readfile_filename_encoding_callback)).

--- a/lib/staticTransform.js
+++ b/lib/staticTransform.js
@@ -105,7 +105,7 @@ function createMiddleware(options) {
           if (options.cache) {
             var expire = new Date();
             expire.setYear(expire.getFullYear() + 1);
-            headers['Expires'] = expire.toUTCString();
+            headers['Expires'] = options.expires || expire.toUTCString();
             headers['Cache-Control'] = 'public, max-age=' + (options.maxage || 31536000/*One year in seconds*/);
             headers['Last-Modified'] = stat.mtime.toUTCString();
             cache[path] = {out: out, headers: headers};


### PR DESCRIPTION
By default expires is set as current year + 1, but in some caching cases we must have control over "Expires" header as well.